### PR TITLE
Using an internal versioning scheme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.streams</groupId>
     <artifactId>streams-project</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
 
     <name>Apache Streams Project</name>
 

--- a/poms/compiled/pom.xml
+++ b/poms/compiled/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.streams.build</groupId>
     <artifactId>shared-plugin-settings</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>compiled-bundle-settings</artifactId>

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.streams</groupId>
     <artifactId>streams-project</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.streams.build</groupId>

--- a/poms/wrappers/pom.xml
+++ b/poms/wrappers/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.streams.build</groupId>
     <artifactId>shared-plugin-settings</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>wrapper-bundle-settings</artifactId>

--- a/provision/pom.xml
+++ b/provision/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.streams</groupId>
     <artifactId>streams-project</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.streams.build</groupId>

--- a/streams-config/pom.xml
+++ b/streams-config/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-project</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-config</artifactId>

--- a/streams-contrib/pom.xml
+++ b/streams-contrib/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-project</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-cassandra/pom.xml
+++ b/streams-contrib/streams-persist-cassandra/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-persist-cassandra</artifactId>

--- a/streams-contrib/streams-persist-console/pom.xml
+++ b/streams-contrib/streams-persist-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-pojo</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/streams-contrib/streams-persist-elasticsearch/pom.xml
+++ b/streams-contrib/streams-persist-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-hbase/pom.xml
+++ b/streams-contrib/streams-persist-hbase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-hdfs/pom.xml
+++ b/streams-contrib/streams-persist-hdfs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-kafka/pom.xml
+++ b/streams-contrib/streams-persist-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-mongo/pom.xml
+++ b/streams-contrib/streams-persist-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-processor-urls/pom.xml
+++ b/streams-contrib/streams-processor-urls/pom.xml
@@ -5,12 +5,12 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-processor-urls</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
 
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/streams-contrib/streams-provider-datasift/pom.xml
+++ b/streams-contrib/streams-provider-datasift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-facebook/pom.xml
+++ b/streams-contrib/streams-provider-facebook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-provider-facebook</artifactId>

--- a/streams-contrib/streams-provider-gnip/gnip-edc-facebook/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-facebook/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-provider-gnip</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-provider-facebook</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>

--- a/streams-contrib/streams-provider-gnip/gnip-edc-flickr/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-flickr/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-provider-gnip</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/gnip-edc-googleplus/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-googleplus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-gnip</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/gnip-edc-instagram/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-instagram/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-gnip</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/gnip-edc-reddit/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-reddit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-gnip</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/gnip-edc-youtube/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-youtube/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>streams-provider-gnip</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/gnip-powertrack/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-powertrack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-gnip</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-gnip/pom.xml
+++ b/streams-contrib/streams-provider-gnip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-google/google-gmail/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gmail/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-google</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-google/google-gplus/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gplus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-google</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-google/pom.xml
+++ b/streams-contrib/streams-provider-google/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-moreover/pom.xml
+++ b/streams-contrib/streams-provider-moreover/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-rss/pom.xml
+++ b/streams-contrib/streams-provider-rss/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-sysomos/pom.xml
+++ b/streams-contrib/streams-provider-sysomos/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-twitter/pom.xml
+++ b/streams-contrib/streams-provider-twitter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-core/pom.xml
+++ b/streams-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-project</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-core</artifactId>

--- a/streams-osgi-components/activity-consumer/pom.xml
+++ b/streams-osgi-components/activity-consumer/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.streams.osgi.components</groupId>
     <artifactId>streams-osgi-components</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>activity-consumer</artifactId>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-persist-cassandra</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/streams-osgi-components/activity-registration/pom.xml
+++ b/streams-osgi-components/activity-registration/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.streams.osgi.components</groupId>
     <artifactId>streams-osgi-components</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>activity-registration</artifactId>

--- a/streams-osgi-components/activity-subscriber/pom.xml
+++ b/streams-osgi-components/activity-subscriber/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.streams.osgi.components</groupId>
     <artifactId>streams-osgi-components</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>activity-subscriber</artifactId>

--- a/streams-osgi-components/pom.xml
+++ b/streams-osgi-components/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.streams</groupId>
     <artifactId>streams-project</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.streams.osgi.components</groupId>

--- a/streams-osgi-components/streams-components-all/pom.xml
+++ b/streams-osgi-components/streams-components-all/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.streams.osgi.components</groupId>
     <artifactId>streams-osgi-components</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>streams-components-all</artifactId>

--- a/streams-pojo/pom.xml
+++ b/streams-pojo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-project</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-runtimes/pom.xml
+++ b/streams-runtimes/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-project</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-runtimes</artifactId>

--- a/streams-runtimes/streams-runtime-local/pom.xml
+++ b/streams-runtimes/streams-runtime-local/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-runtimes</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-runtime-local</artifactId>
@@ -46,17 +46,17 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-util</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-pojo</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/streams-runtimes/streams-runtime-pig/pom.xml
+++ b/streams-runtimes/streams-runtime-pig/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-runtimes</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-runtime-pig</artifactId>
@@ -37,35 +37,35 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-runtime-local</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-runtime-local</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
             <scope>test-jar</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-provider-twitter</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
             <scope>test-jar</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-util</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/streams-runtimes/streams-runtime-storm/pom.xml
+++ b/streams-runtimes/streams-runtime-storm/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-runtimes</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-runtime-storm</artifactId>
@@ -38,17 +38,17 @@
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-core</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-util</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1.0-W2O-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/streams-runtimes/streams-runtime-webapp/pom.xml
+++ b/streams-runtimes/streams-runtime-webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.streams</groupId>
     <artifactId>streams-runtimes</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
 
   <artifactId>streams-runtime-webapp</artifactId>

--- a/streams-util/pom.xml
+++ b/streams-util/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-project</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.0-W2O-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-web/pom.xml
+++ b/streams-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>streams-project</artifactId>
     <groupId>org.apache.streams</groupId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.0-W2O-SNAPSHOT</version>
   </parent>
   <artifactId>streams-web</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Set using maven-versions-plugin.

Our internal builds will depend on this version and we will cut internal releases using the incremental version number, so that the major and minor version numbers are consistent with Apache.
