### PR TITLE
STREAMS-103 | The run method in StatusCounterMonitorThread caught the In...

### DIFF
--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StatusCounterMonitorThread.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StatusCounterMonitorThread.java
@@ -4,8 +4,7 @@ import org.apache.streams.core.DatumStatusCountable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StatusCounterMonitorThread implements StatusCounterMonitorRunnable
-{
+public class StatusCounterMonitorThread implements StatusCounterMonitorRunnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(StatusCounterMonitorThread.class);
 
     private DatumStatusCountable task;
@@ -20,7 +19,7 @@ public class StatusCounterMonitorThread implements StatusCounterMonitorRunnable
     }
 
     @Override
-    public void shutdown(){
+    public void shutdown() {
         this.run = false;
     }
 
@@ -30,9 +29,8 @@ public class StatusCounterMonitorThread implements StatusCounterMonitorRunnable
     }
 
     @Override
-    public void run()
-    {
-        while(run){
+    public void run() {
+        while(run) {
 
             /**
              *
@@ -50,13 +48,12 @@ public class StatusCounterMonitorThread implements StatusCounterMonitorRunnable
                     task.getDatumStatusCounter().getFail(),
                     task.getDatumStatusCounter().getEmitted());
 
-            try
-            {
+            try {
                 Thread.sleep(seconds*1000);
             }
-            catch (InterruptedException e)
-            { }
+            catch (InterruptedException e){
+                shutdown();
+            }
         }
     }
-
 }


### PR DESCRIPTION
...terruptedException, but never did anything with it. As a result, any calls to this.monitor.shutdownNow() were essentially ignored. Added in an explicit call to its shutdown method once that interrupt is received
