### PR TITLE
Fix conflicts between apache:master and w2ogroup:master

### DIFF
--- a/streams-monitoring/src/main/java/org/apache/streams/monitoring/tasks/BroadcastMonitorThread.java
+++ b/streams-monitoring/src/main/java/org/apache/streams/monitoring/tasks/BroadcastMonitorThread.java
@@ -116,10 +116,11 @@ public class BroadcastMonitorThread extends NotificationBroadcasterSupport imple
                 Thread.sleep(waitTime);
             } catch (InterruptedException e) {
                 LOGGER.error("Interrupted!: {}", e);
-                keepRunning = false;
                 Thread.currentThread().interrupt();
+                this.keepRunning = false;
             } catch (Exception e) {
                 LOGGER.error("Exception: {}", e);
+                this.keepRunning = false;
             }
         }
     }

--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
@@ -114,6 +114,9 @@ public class StreamsPersistWriterTask extends BaseStreamsTask implements DatumSt
                 } catch (InterruptedException ie) {
                     LOGGER.debug("Received InterruptedException. Shutting down and re-applying interrupt status.");
                     this.keepRunning.set(false);
+                    if(!this.inQueue.isEmpty()) {
+                        LOGGER.error("Received InteruptedException and input queue still has data, count={}, processor={}",this.inQueue.size(), this.writer.getClass().getName());
+                    }
                     Thread.currentThread().interrupt();
                 } finally {
                     this.blocked.set(false);

--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsProcessorTask.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsProcessorTask.java
@@ -123,6 +123,9 @@ public class StreamsProcessorTask extends BaseStreamsTask implements DatumStatus
                 } catch (InterruptedException ie) {
                     LOGGER.debug("Received InteruptedException, shutting down and re-applying interrupt status.");
                     this.keepRunning.set(false);
+                    if(!this.inQueue.isEmpty()) {
+                        LOGGER.error("Received InteruptedException and input queue still has data, count={}, processor={}",this.inQueue.size(), this.processor.getClass().getName());
+                    }
                     Thread.currentThread().interrupt();
                 } finally {
                     this.blocked.set(false);


### PR DESCRIPTION
1. Branched w2ogroup:master to create w2ogroup:w2o-master-conflicts
2. Merged apache:master into w2ogroup:w2o-master-conflicts
3. Resolved merge conflicts
4. Opened this pull request for merging w2ogroup:w2o-master-conflicts into w2ogroup:master

```
            } catch (InterruptedException e) {
                LOGGER.error("Interrupted!: {}", e);
<<<<<<< HEAD
                keepRunning = false;
                Thread.currentThread().interrupt();
=======
                Thread.currentThread().interrupt();
                this.keepRunning = false;
>>>>>>> apache/master
            } catch (Exception e) {
                LOGGER.error("Exception: {}", e);
                this.keepRunning = false;
            }
        }
    }
```
