### PR TITLE
STREAMS-297 | RSS Link Provider

### DIFF
--- a/streams-contrib/streams-provider-rss/pom.xml
+++ b/streams-contrib/streams-provider-rss/pom.xml
@@ -98,6 +98,11 @@
             <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-runtime-threaded</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssLinkProvider.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssLinkProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.streams.rss.provider;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Queues;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.streams.core.StreamsDatum;
+import org.apache.streams.core.StreamsProvider;
+import org.apache.streams.core.StreamsResultSet;
+import org.apache.streams.rss.serializer.SyndEntrySerializer;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class RssLinkProvider extends RssProvider implements StreamsProvider {
+    private final static Logger LOGGER = LoggerFactory.getLogger(RssProvider.class);
+    private Set<String> feeds;
+
+    public RssLinkProvider(Set<String> feeds) {
+        this.feeds = feeds;
+    }
+
+    @Override
+    protected boolean continuePulling(ObjectNode obj) {
+        return true;
+    }
+
+    @Override
+    public void startStream() {
+        this.perpetual = true;
+        LOGGER.info("** Starting RSS Thread. **");
+        this.executor.execute(new PollingTask(this, this.feeds));
+    }
+
+    @Override
+    public StreamsResultSet readCurrent() {
+        Queue<StreamsDatum> result = Queues.newConcurrentLinkedQueue();
+        synchronized (this.entries) {
+            if(this.entries.isEmpty() && this.doneProviding.get()) {
+                this.keepRunning.set(false);
+            }
+
+            while(!this.entries.isEmpty()) {
+                ObjectNode node = this.entries.poll();
+
+                try {
+                    while (!result.offer(new StreamsDatum(node.get("uri").asText()))) {
+                        Thread.yield();
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Problem offering up new StreamsDatum: {}", node.asText());
+                }
+            }
+        }
+        LOGGER.debug("** ReadCurrent return {} streams datums", result.size());
+
+        return new StreamsResultSet(result);
+    }
+
+    @Override
+    public StreamsResultSet readNew(BigInteger bigInteger) {
+        throw new NotImplementedException("readNew not implemented for " + this.getClass().toString());
+    }
+
+    @Override
+    public StreamsResultSet readRange(DateTime dateTime, DateTime dateTime1) {
+        throw new NotImplementedException("readRange not implemented for " + this.getClass().toString());
+    }
+
+    @Override
+    public boolean isRunning() {
+        return this.keepRunning.get();
+    }
+
+    @Override
+    public void prepare(Object o) {
+        this.entries = new ConcurrentLinkedQueue<ObjectNode>();
+        this.serializer = new SyndEntrySerializer();
+        this.executor = Executors.newSingleThreadExecutor();
+        this.keepRunning = new AtomicBoolean(true);
+        this.doneProviding = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void cleanUp() {
+        if(this.executor != null) {
+            this.executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Runnable class that pulls down entries for a given RSS Feed
+     */
+    private class PollingTask implements Runnable {
+
+        private RssProvider provider;
+        private Set<String> feeds;
+
+        public PollingTask(RssProvider provider, Set<String> feeds) {
+            this.provider = provider;
+            this.feeds = feeds;
+        }
+
+        @Override
+        public void run() {
+            this.provider.pullRssData(this.feeds);
+        }
+    }
+}

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssProvider.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssProvider.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class RssProvider {
     private final static Logger LOGGER = LoggerFactory.getLogger(RssProvider.class);
-
+    private final int DEFAULT_TIMEOUT = 10000; //10 seconds in milliseconds
     protected Queue<ObjectNode> entries;
     protected boolean perpetual = true;
     protected SyndEntrySerializer serializer;
@@ -84,11 +84,7 @@ public abstract class RssProvider {
      * @throws com.sun.syndication.io.FeedException
      */
     public void pullData(URL feedUrl) throws IOException, FeedException {
-        SyndFeedInput input = new SyndFeedInput();
-        URLConnection connection = feedUrl.openConnection();
-        connection.setConnectTimeout(10000);
-        connection.setReadTimeout(10000);
-        SyndFeed feed = buildFeed(feedUrl);//input.build(new InputStreamReader(connection.getInputStream()));
+        SyndFeed feed = buildFeed(feedUrl);
 
         for(Object entryObj : feed.getEntries()) {
             SyndEntry entry = (SyndEntry) entryObj;
@@ -107,6 +103,11 @@ public abstract class RssProvider {
         }
     }
 
+    /**
+     * Given a url for an RSS feed, return a SyndFeed object containing all posts
+     * @param feedUrl
+     * @return
+     */
     protected SyndFeed buildFeed(URL feedUrl) {
         SyndFeed feed = null;
 
@@ -114,8 +115,8 @@ public abstract class RssProvider {
             SyndFeedInput input = new SyndFeedInput();
 
             URLConnection connection = feedUrl.openConnection();
-            connection.setConnectTimeout(10000);
-            connection.setReadTimeout(10000);
+            connection.setConnectTimeout(DEFAULT_TIMEOUT);
+            connection.setReadTimeout(DEFAULT_TIMEOUT);
 
             feed = input.build(new InputStreamReader(connection.getInputStream()));
         } catch (Exception e) {

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssProvider.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssProvider.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.streams.rss.provider;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
+import com.sun.syndication.feed.synd.SyndEntry;
+import com.sun.syndication.feed.synd.SyndFeed;
+import com.sun.syndication.io.FeedException;
+import com.sun.syndication.io.SyndFeedInput;
+import org.apache.streams.rss.serializer.SyndEntrySerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class RssProvider {
+    private final static Logger LOGGER = LoggerFactory.getLogger(RssProvider.class);
+
+    protected Queue<ObjectNode> entries;
+    protected boolean perpetual = true;
+    protected SyndEntrySerializer serializer;
+    protected ExecutorService executor;
+    protected AtomicBoolean keepRunning;
+    protected AtomicBoolean doneProviding;
+    protected Set<String> previouslySeen;
+
+    public RssProvider() {
+    }
+
+    /**
+     * Polls all of the rss feeds and adds the results to the the queue of SyndEntries
+     * @param rssFeeds rss feeds to read and processes
+     */
+    public void pullRssData(Set<String> rssFeeds) {
+        if(this.previouslySeen == null) {
+            this.previouslySeen = Sets.newHashSet();
+        }
+
+        for (String rssFeed : rssFeeds) {
+            LOGGER.debug("Attempting to read rss feed : {}", rssFeed);
+            LOGGER.debug("whatever");
+            try {
+                URL feedUrl = new URL(rssFeed);
+                pullData(feedUrl);
+            } catch (Exception e) {
+                LOGGER.error("Failed to connect to a read rss feed : {}", rssFeed);
+                LOGGER.error("Exception while trying to connect and read feed : {}", e);
+            }
+        }
+
+        if(this.perpetual) {
+            this.doneProviding.set(true);
+        }
+    }
+
+    /**
+     * Adds the data from a feed urls to the queue of SyndEntries. Only queues the entries that were not seen in last
+     * poll request.
+     * @param feedUrl
+     * @throws java.io.IOException
+     * @throws com.sun.syndication.io.FeedException
+     */
+    public void pullData(URL feedUrl) throws IOException, FeedException {
+        SyndFeedInput input = new SyndFeedInput();
+        URLConnection connection = feedUrl.openConnection();
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(10000);
+        SyndFeed feed = buildFeed(feedUrl);//input.build(new InputStreamReader(connection.getInputStream()));
+
+        for(Object entryObj : feed.getEntries()) {
+            SyndEntry entry = (SyndEntry) entryObj;
+            ObjectNode nodeEntry = this.serializer.deserialize(entry);
+            nodeEntry.put("rssFeed", feedUrl.toString());
+
+            if(!continuePulling(nodeEntry)) {
+                break;
+            }
+
+            synchronized (this.entries) {
+                while(!this.entries.offer(nodeEntry)) {
+                    Thread.yield();
+                }
+            }
+        }
+    }
+
+    protected SyndFeed buildFeed(URL feedUrl) {
+        SyndFeed feed = null;
+
+        try {
+            SyndFeedInput input = new SyndFeedInput();
+
+            URLConnection connection = feedUrl.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
+
+            feed = input.build(new InputStreamReader(connection.getInputStream()));
+        } catch (Exception e) {
+            LOGGER.error("Exception while trying to build RSS feed for: {}, {}", feedUrl, e);
+        }
+
+        return feed;
+    }
+
+    /**
+     * Given a RSS document, determine whether or not we need to continue pulling articles
+     * @param obj
+     * @return boolean Whether or not we need to continue pulling from this feed. Dependent on latest doc in ES
+     */
+    protected abstract boolean continuePulling(ObjectNode obj);
+}

--- a/streams-contrib/streams-provider-rss/src/test/java/org/apache/streams/rss/provider/CollectorProcessor.java
+++ b/streams-contrib/streams-provider-rss/src/test/java/org/apache/streams/rss/provider/CollectorProcessor.java
@@ -1,0 +1,39 @@
+package org.apache.streams.rss.provider;
+
+import com.google.common.collect.Lists;
+import org.apache.streams.core.StreamsDatum;
+import org.apache.streams.core.StreamsProcessor;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CollectorProcessor implements StreamsProcessor {
+    private AtomicInteger docCount = new AtomicInteger(0);
+
+    public CollectorProcessor() {
+        super();
+    }
+
+    @Override
+    public List<StreamsDatum> process(StreamsDatum entry) {
+        if(entry != null && entry.getDocument() != null && entry.getDocument().toString().length() > 0) {
+            docCount.addAndGet(1);
+        }
+
+        return Lists.newArrayList(entry);
+    }
+
+    @Override
+    public void prepare(Object configurationObject) {
+
+    }
+
+    @Override
+    public void cleanUp() {
+
+    }
+
+    public int getDocCount() {
+        return docCount.get();
+    }
+}

--- a/streams-contrib/streams-provider-rss/src/test/java/org/apache/streams/rss/provider/RssLinkProviderTest.java
+++ b/streams-contrib/streams-provider-rss/src/test/java/org/apache/streams/rss/provider/RssLinkProviderTest.java
@@ -1,0 +1,56 @@
+package org.apache.streams.rss.provider;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.sun.syndication.feed.synd.SyndEntry;
+import com.sun.syndication.feed.synd.SyndEntryImpl;
+import com.sun.syndication.feed.synd.SyndFeed;
+import com.sun.syndication.feed.synd.SyndFeedImpl;
+import org.apache.streams.threaded.builders.ThreadedStreamBuilder;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class RssLinkProviderTest {
+
+    @Test
+    public void testProvider() {
+        ThreadedStreamBuilder builder = new ThreadedStreamBuilder();
+        Set<String> feeds = Sets.newHashSet();
+
+        feeds.add("http://google.com");
+        feeds.add("http://testFeed2.com");
+        feeds.add("http://testFeed3.com");
+
+        RssLinkTestProvider provider = new RssLinkTestProvider(feeds);
+        CollectorProcessor processor = new CollectorProcessor();
+
+        builder.newPerpetualStream("rssProvider", provider)
+                .addStreamsProcessor("collectorProcessor", processor, 1, "rssProvider");
+
+        builder.start();
+
+        assertEquals("Did not get correct number of url entries.", processor.getDocCount(), feeds.size());
+    }
+
+    private class RssLinkTestProvider extends RssLinkProvider {
+
+        public RssLinkTestProvider(Set<String> feeds) {
+            super(feeds);
+        }
+
+        @Override
+        protected SyndFeed buildFeed(URL feedUrl) {
+            SyndFeed entry = new SyndFeedImpl();
+            SyndEntry obj = new SyndEntryImpl();
+            obj.setUri(feedUrl.toString());
+
+            entry.setEntries(Lists.newArrayList(obj));
+
+            return entry;
+        }
+    }
+}


### PR DESCRIPTION
This provider operates off of a set of RSS feed URLs. Instead of returning extracted documents, it returns the links to all of the posts for those RSS feeds.