### PR TITLE
SBP-1860 | Removing duplicate 'batchSize' attribute from the ES reader a...

### DIFF
--- a/streams-contrib/streams-persist-elasticsearch/src/main/jsonschema/org/apache/streams/elasticsearch/ElasticsearchReaderConfiguration.json
+++ b/streams-contrib/streams-persist-elasticsearch/src/main/jsonschema/org/apache/streams/elasticsearch/ElasticsearchReaderConfiguration.json
@@ -28,11 +28,6 @@
             "description": "Scroll Timeout (JodaTime)",
             "default": "5m"
         },
-        "batchSize": {
-          "type": "integer",
-          "descripton" : "The batch size",
-          "default": 100
-        },
         "_search": {
             "type": "object",
             "javaType" : "java.util.Map",

--- a/streams-contrib/streams-persist-elasticsearch/src/main/jsonschema/org/apache/streams/elasticsearch/ElasticsearchWriterConfiguration.json
+++ b/streams-contrib/streams-persist-elasticsearch/src/main/jsonschema/org/apache/streams/elasticsearch/ElasticsearchWriterConfiguration.json
@@ -22,11 +22,6 @@
             "description": "Index in large or small batches",
             "default": "false"
         },
-        "batchSize": {
-            "type": "integer",
-            "description": "Item Count before flush",
-            "default": 100
-        },
         "batchBytes": {
             "type": "integer",
             "description": "Number of bytes before flush",

--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
@@ -131,6 +131,8 @@ public class LocalStreamBuilder implements StreamBuilder {
         try {
             if (streamConfig.containsKey("maxQueueSize") && Integer.valueOf((Integer) streamConfig.get("maxQueueSize")) > 0) {
                 this.maxQueueCapacity = Integer.valueOf((Integer) streamConfig.get("maxQueueSize"));
+            } else {
+                this.maxQueueCapacity = DEFAULT_QUEUE_SIZE;
             }
         } catch (Exception e) {
             LOGGER.error("Exception while trying to parse the max queue size from the Stream configuration object: {}", e);


### PR DESCRIPTION
...nd writer configuration schemas. The batchSize is already an attribute of the base ES configuration and these resulted in having duplicates. Fixed issue where LocalStreamBuilder would get a NPE if a maxQueueSize was not set in the Streams config