### PR TITLE
SBP-2174 | Allows us to set the timestamp of the Streams datum from S3 d...

### DIFF
--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/java/org/apache/streams/s3/S3PersistReaderTask.java
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/java/org/apache/streams/s3/S3PersistReaderTask.java
@@ -72,7 +72,7 @@ public class S3PersistReaderTask implements Runnable {
                         if(publishedDate != null) {
                             entry = new StreamsDatum(fields[3], fields[0], publishedDate);
                         } else {
-                            new StreamsDatum(fields[3], fields[0]);
+                            entry = new StreamsDatum(fields[3], fields[0]);
                         }
 
                         ComponentUtils.offerUntilSuccess(entry, reader.persistQueue);

--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/jsonschema/org/apache/streams/s3/S3ReaderConfiguration.json
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/jsonschema/org/apache/streams/s3/S3ReaderConfiguration.json
@@ -12,6 +12,11 @@
         "readerPath": {
             "type": "string",
             "description": "Path below root path"
+        },
+        "useTimestampAsPublished": {
+            "type": "boolean",
+            "description": "Whether or not we want to use the timestamp stored in S3 (if it exists) as the document's published time",
+            "default": false
         }
     }
 }

--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/src/test/java/org/apache/streams/s3/S3PersistReaderTest.java
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/src/test/java/org/apache/streams/s3/S3PersistReaderTest.java
@@ -1,0 +1,59 @@
+package org.apache.streams.s3;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class S3PersistReaderTest {
+
+    @Test
+    public void testUseTimestampAsPublishedEnabled() {
+        S3ReaderConfiguration config = new S3ReaderConfiguration();
+        config.setUseTimestampAsPublished(true);
+
+        S3PersistReader s3PersistReader = new S3PersistReader(config);
+        S3PersistReaderTask s3PersistReaderTask = new S3PersistReaderTask(s3PersistReader);
+
+        DateTime publishedDate = s3PersistReaderTask.getPublishedDate(new String[]{"id", "2015-01-14T13:58:08.100-06:00", ""});
+
+        assertEquals(publishedDate.toString(), "2015-01-14T13:58:08.100-06:00");
+    }
+
+    @Test
+    public void testUseTimestampAsPublishedDisabled() {
+        S3ReaderConfiguration config = new S3ReaderConfiguration();
+        config.setUseTimestampAsPublished(false);
+
+        S3PersistReader s3PersistReader = new S3PersistReader(config);
+        S3PersistReaderTask s3PersistReaderTask = new S3PersistReaderTask(s3PersistReader);
+
+        DateTime publishedDate = s3PersistReaderTask.getPublishedDate(new String[]{"id", "2015-01-14T13:58:08.100-06:00", ""});
+
+        assertEquals(publishedDate, null);
+    }
+
+    @Test
+    public void testUseTimestampAsPublishedNull() {
+        S3ReaderConfiguration config = new S3ReaderConfiguration();
+
+        S3PersistReader s3PersistReader = new S3PersistReader(config);
+        S3PersistReaderTask s3PersistReaderTask = new S3PersistReaderTask(s3PersistReader);
+
+        DateTime publishedDate = s3PersistReaderTask.getPublishedDate(new String[]{"id", "2015-01-14T13:58:08.100-06:00", ""});
+
+        assertEquals(publishedDate, null);
+    }
+
+    @Test
+    public void testUseTimestampAsPublishedInvalid() {
+        S3ReaderConfiguration config = new S3ReaderConfiguration();
+
+        S3PersistReader s3PersistReader = new S3PersistReader(config);
+        S3PersistReaderTask s3PersistReaderTask = new S3PersistReaderTask(s3PersistReader);
+
+        DateTime publishedDate = s3PersistReaderTask.getPublishedDate(new String[]{"id", "", ""});
+
+        assertEquals(publishedDate, null);
+    }
+}


### PR DESCRIPTION
...ocuments

In the event that we want to use the logged timestamp in the S3 document as the timestamp in the Streams Datum that gets read, we can set a flag 'useTimestampAsPublished' in the S3ReaderConfiguration to true.