### PR TITLE
SBP-2483 | Ensuring that timeout can occur in ElasticsearchPersistWriter...

### DIFF
--- a/streams-contrib/streams-persist-elasticsearch/src/main/java/org/apache/streams/elasticsearch/ElasticsearchPersistWriter.java
+++ b/streams-contrib/streams-persist-elasticsearch/src/main/java/org/apache/streams/elasticsearch/ElasticsearchPersistWriter.java
@@ -256,7 +256,7 @@ public class ElasticsearchPersistWriter implements StreamsPersistWriter, DatumSt
             try {
                 Thread.yield();
                 Thread.sleep(1);
-                timeOutThresholdInMS++;
+                counter++;
             } catch(InterruptedException ie) {
                 LOGGER.error("Caught interrupted exception: {}", ie);
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
... if it is appropriate. Previously incrementing incorrect variable