### PR TITLE
Ensure the twitter provider doesn't deadlock if its queue is full

### DIFF
--- a/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/provider/TwitterTimelineProvider.java
+++ b/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/provider/TwitterTimelineProvider.java
@@ -294,7 +294,7 @@ public class TwitterTimelineProvider implements StreamsProvider, Serializable {
     }
 
     public void addDatum(StreamsDatum datum) {
-        if (this.lock.readLock().tryLock()) {
+        if (this.lock.writeLock().tryLock()) {
             try {
                 if (this.providerQueue instanceof BlockingQueue) {
                     if (((BlockingQueue) this.providerQueue).remainingCapacity() > 0) {
@@ -309,7 +309,7 @@ public class TwitterTimelineProvider implements StreamsProvider, Serializable {
                     return;
                 }
             } finally {
-                this.lock.readLock().unlock();
+                this.lock.writeLock().unlock();
             }
         } else {
             LOGGER.warn("Lock was in use, will yield and try again");

--- a/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/provider/TwitterTimelineProvider.java
+++ b/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/provider/TwitterTimelineProvider.java
@@ -37,10 +37,7 @@ import twitter4j.conf.ConfigurationBuilder;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -176,7 +173,7 @@ public class TwitterTimelineProvider implements StreamsProvider, Serializable {
     }
 
     protected Queue<StreamsDatum> constructQueue() {
-        return Queues.synchronizedQueue(new LinkedBlockingQueue<StreamsDatum>(MAX_NUMBER_WAITING));
+        return new LinkedBlockingQueue<StreamsDatum>(MAX_NUMBER_WAITING);
     }
 
     public StreamsResultSet readNew(BigInteger sequence) {
@@ -297,11 +294,32 @@ public class TwitterTimelineProvider implements StreamsProvider, Serializable {
     }
 
     public void addDatum(StreamsDatum datum) {
+        if (this.lock.readLock().tryLock()) {
+            try {
+                if (this.providerQueue instanceof BlockingQueue) {
+                    if (((BlockingQueue) this.providerQueue).remainingCapacity() > 0) {
+                        ComponentUtils.offerUntilSuccess(datum, this.providerQueue);
+                        return;
+                    } else {
+                        LOGGER.warn("Queue was at capacity, will yield and try again");
+                    }
+                } else {
+                    LOGGER.warn("Queue was not a blocking queue, will unconditionally offer data");
+                    ComponentUtils.offerUntilSuccess(datum, this.providerQueue);
+                    return;
+                }
+            } finally {
+                this.lock.readLock().unlock();
+            }
+        } else {
+            LOGGER.warn("Lock was in use, will yield and try again");
+        }
         try {
-            lock.readLock().lock();
-            ComponentUtils.offerUntilSuccess(datum, providerQueue);
-        } finally {
-            lock.readLock().unlock();
+            Thread.sleep(5000);
+            addDatum(datum);
+        } catch (InterruptedException e) {
+            LOGGER.error("Interrupted while trying to add a datum.  Datum may be lost. {}", datum.getId());
+            Thread.currentThread().interrupt();
         }
     }
 }


### PR DESCRIPTION
Currently, if the twitter provider's queue is filled and ComponentUtils.offerUntilSuccess() blocks, the provider will deadlock.  This happens because before calling offerUntilSuccess(), a lock is held.  The process to drain the provider queue, which exists in a separate thread, needs that lock to drain the queue.  Thus, we can deadlock when the queue fills and there's no way to drain it.

This solution is admittedly not the best.  The provider should be refactored so that the dataflow can't result in deadlock instead of putting measures in place to avoid said deadlock.

@RichHatch @robdouglas @smashew 