### PR TITLE
Allow the broadcast monitor to gracefully shutdown

### DIFF
--- a/streams-monitoring/src/main/java/org/apache/streams/monitoring/tasks/BroadcastMonitorThread.java
+++ b/streams-monitoring/src/main/java/org/apache/streams/monitoring/tasks/BroadcastMonitorThread.java
@@ -43,9 +43,13 @@ public class BroadcastMonitorThread extends LocalRuntimeBroadcastMonitorThread i
                 persistMessages();
                 Thread.sleep(getWaitTime());
             } catch (InterruptedException e) {
-                LOGGER.error("Interrupted!: {}", e);
+                if (this.keepRunning) {
+                    LOGGER.error("Interrupted before a proper shutdown: {}", e);
+                    this.keepRunning = false;
+                } else {
+                    LOGGER.debug("Interrupted after a proper shutdown.  Continuing to shutdown.");
+                }
                 Thread.currentThread().interrupt();
-                this.keepRunning = false;
             }
         }
     }

--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
@@ -62,7 +62,7 @@ public class LocalStreamBuilder implements StreamBuilder {
     private LocalStreamProcessMonitorThread monitorThread;
     private Map<String, List<StreamsTask>> tasks;
     private Thread shutdownHook;
-    private BroadcastMonitorThread broadcastMonitor;
+    private final BroadcastMonitorThread broadcastMonitor;
     private int maxQueueCapacity;
     private String streamIdentifier = DEFAULT_STREAM_IDENTIFIER;
     private DateTime startedAt = new DateTime();
@@ -300,15 +300,19 @@ public class LocalStreamBuilder implements StreamBuilder {
             this.monitorThread.shutdown();
         }
         this.executor.shutdown();
-        //complete stream shut down gracfully
+        //complete stream shut down gracefully
         for(StreamComponent prov : this.providers.values()) {
             shutDownTask(prov, streamsTasks);
         }
+
         //need to make this configurable
         if(!this.executor.awaitTermination(10, TimeUnit.SECONDS)) { // all threads should have terminated already.
             this.executor.shutdownNow();
             this.executor.awaitTermination(10, TimeUnit.SECONDS);
         }
+
+        this.monitor.shutdown();
+        this.broadcastMonitor.shutdown();
         if(!this.monitor.awaitTermination(5, TimeUnit.SECONDS)) { // all threads should have terminated already.
             this.monitor.shutdownNow();
             this.monitor.awaitTermination(5, TimeUnit.SECONDS);


### PR DESCRIPTION
As opposed to never shutting it down, forcefully interrupting it and logging that as an error.  This results in the logs for streams always showing tons of errors from the broadcast monitor.

The fix here will only log errors if the interruption came before a proper shutdown.

@RichHatch @robdouglas @smashew 