### PR TITLE
SBP-2853 | Removed log statement when the StreamsPersistWriterTask is…

### DIFF
--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
@@ -147,6 +147,7 @@ public class StreamsPersistWriterTask extends BaseStreamsTask implements DatumSt
                 Thread.sleep(5000);
             } catch (InterruptedException e) {
                 //This is the expected behavior when this thread is killed
+                LOGGER.info("Streams Persist Writer Task interrupted while shutting down components: {}", e);
             }
             this.writer.cleanUp();
             this.isRunning.set(false);

--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/tasks/StreamsPersistWriterTask.java
@@ -146,7 +146,7 @@ public class StreamsPersistWriterTask extends BaseStreamsTask implements DatumSt
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException e) {
-                LOGGER.error("Sleep interrupted: {}", e);
+                //This is the expected behavior when this thread is killed
             }
             this.writer.cleanUp();
             this.isRunning.set(false);


### PR DESCRIPTION
… killed after runtime is shut down